### PR TITLE
Limit numpy version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 ### BEGIN ###
 pydub>=0.9.4
 PyAudio>=0.2.7
-numpy>=1.8.2
+numpy>=1.8.2, <=1.13.1
 scipy>=0.12.1
 matplotlib>=1.3.1
 ### END ###


### PR DESCRIPTION
Numpy must be limited to version 1.13.1 (Python 2.7 environment)
I'm using numpy 1.14.5 has a different syntax for https://github.com/worldveil/dejavu/blob/master/dejavu/fingerprint.py#L104

Error:

detected_peaks = local_max - eroded_background
TypeError: numpy boolean subtract, the `-` operator, is deprecated, use the bitwise_xor, the `^` operator, or the logical_xor function instead.